### PR TITLE
Fix a variable unit for transmission

### DIFF
--- a/definitions/variable/grids infrastructure/gas_grid.yaml
+++ b/definitions/variable/grids infrastructure/gas_grid.yaml
@@ -33,10 +33,10 @@
         unit: GW
 - Network|Natural Gas|Capacity:
         description: Upper bound of natural gas pipeline capacity.
-        unit: GW/h
+        unit: GW
 - Network|Hydrogen|Capacity:
         description: Upper bound of hydrogen pipeline capacity.
-        unit: GW/h
+        unit: GW
 - Network|Hydrogen|Length:
         description: Length of the hydrogen pipeline.
         unit: km


### PR DESCRIPTION
When looking through the current definitions, I realized that the capacity of the gas grid network variable was given with a unit `GW/h`. This unit does not correspond to a capacity but (potentially) the rate of change in the capacity.

I would guess that `GW` was meant? Can you confirm that @enokandi ?