### PR TITLE
Activate validation for datetime-format timeseries

### DIFF
--- a/nomenclature.yaml
+++ b/nomenclature.yaml
@@ -16,5 +16,6 @@ definitions:
       nuts-2: true
       nuts-3: true
 time:
+  year: true
   datetime: true
   timezone: UTC+01:00

--- a/nomenclature.yaml
+++ b/nomenclature.yaml
@@ -15,3 +15,6 @@ definitions:
       nuts-1: true
       nuts-2: true
       nuts-3: true
+time:
+  datetime: true
+  timezone: UTC+01:00

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pyam-iamc >= 2.1  # the `pyam` package is released on pypi under this name
-nomenclature-iamc >= 0.21
+nomenclature-iamc >= 0.25.1


### PR DESCRIPTION
This PR activates the validation for datetime-format timeseries using the latest nomenclature release.