### PR TITLE
Allow reporting of power generation in GWh/h

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ Please make sure to follow the instructions completely, both the _Model mapping_
 4. Set [@danielhuppmann](https://github.com/danielhuppmann) and [@phackstock](https://github.com/phackstock) as reviewers.
 5. Once everything is in order we will merge your pull request and your model will be registered.
 
+## Reporting of subannual timeseries
+
+This project supports reporting of timeseries with yearly, datetime and categorical
+timesteps (see [subannual](subannual) for definitions of categorical timeslices).
+For subannual resolution of power generation, the unit `GWh/h` should be used, while
+`EJ/yr` should be used for yearly reporting for consistency and comparability with
+other projects.
+
 ### Workflow
 
 The module `workflow.py` has a function `main(df: pyam.IamDataFrame) -> pyam.IamDataFrame:`.

--- a/definitions/variable/electricity.yaml
+++ b/definitions/variable/electricity.yaml
@@ -1,7 +1,13 @@
 # This file adds needed variables for the EMPIRE data upload
+- Secondary Energy|Electricity:
+    description: Total net electricity generation
+    unit: [EJ/yr, GWh/h]
+- Secondary Energy|Electricity|{Electricity Source}:
+    description: Net electricity generation from {Electricity Source}
+    unit: [EJ/yr, GWh/h]
 - Secondary Energy|Electricity|{Electricity Source By Technology}:
      description: Net electricity generation from {Electricity Source By Technology}
-     unit: EJ/yr
+     unit: [EJ/yr, GWh/h]
 - Investment|Energy Supply|Electricity|{Electricity Source By Technology}:
     description: Investment in {Electricity Source By Technology}
     unit: billion USD_2010/yr

--- a/nomenclature.yaml
+++ b/nomenclature.yaml
@@ -10,6 +10,9 @@ definitions:
     repository:
       name: common-definitions
       exclude:
+        # power generation redefined with unit GWh/h for subannual reporting
+        - name: Secondary Energy|Electricity*
+        # carbon price redefined with unit EUR_2020/t CO2
         - name: Price|Carbon
   region:
     nuts:


### PR DESCRIPTION
This PR extends the variable template so the `GWh/h` can be reported for power generation. It adds a note to the readme clarifying that `GWh/h` should only be used for subannual reporting.

@pdpsi @phackstock 