### PR TITLE
Activate NUTS-region-processing for `JRC-EU-TIMES-OP 0.1.0`

### DIFF
--- a/nomenclature.yaml
+++ b/nomenclature.yaml
@@ -21,7 +21,7 @@ definitions:
       nuts-3: true
 processors:
   nuts:
-    - JRC-EU-TIMES-OP 0.1.0
+    - JRC-EU-TIMES-OP North Sea 0.1.0
 time_domain:
   year: true
   datetime: true

--- a/nomenclature.yaml
+++ b/nomenclature.yaml
@@ -19,6 +19,9 @@ definitions:
       nuts-1: true
       nuts-2: true
       nuts-3: true
+processors:
+  nuts:
+    - JRC-EU-TIMES-OP 0.1.0
 time_domain:
   year: true
   datetime: true


### PR DESCRIPTION
@pdpsi, if you report all NUTS regions for the countries that you include, the Scenario Explorer processing can automatically compute aggregates for NUTS1 and country-level. Please approve this PR if you do report all NUTS2 regions for the modelled countries and want to activate this feature.