### PR TITLE
Use MWh/h for subannual power-generation reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Please make sure to follow the instructions completely, both the _Model mapping_
 
 This project supports reporting of timeseries with yearly, datetime and categorical
 timesteps (see [subannual](subannual) for definitions of categorical timeslices).
-For subannual resolution of power generation, the unit `GWh/h` should be used, while
+For subannual resolution of power generation, the unit `MWh/h` should be used, while
 `EJ/yr` should be used for yearly reporting for consistency and comparability with
 other projects.
 

--- a/definitions/variable/electricity.yaml
+++ b/definitions/variable/electricity.yaml
@@ -1,13 +1,13 @@
 # This file adds needed variables for the EMPIRE data upload
 - Secondary Energy|Electricity:
     description: Total net electricity generation
-    unit: [EJ/yr, GWh/h]
+    unit: [EJ/yr, MWh/h]
 - Secondary Energy|Electricity|{Electricity Source}:
     description: Net electricity generation from {Electricity Source}
-    unit: [EJ/yr, GWh/h]
+    unit: [EJ/yr, MWh/h]
 - Secondary Energy|Electricity|{Electricity Source By Technology}:
      description: Net electricity generation from {Electricity Source By Technology}
-     unit: [EJ/yr, GWh/h]
+     unit: [EJ/yr, MWh/h]
 - Investment|Energy Supply|Electricity|{Electricity Source By Technology}:
     description: Investment in {Electricity Source By Technology}
     unit: billion USD_2010/yr

--- a/nomenclature.yaml
+++ b/nomenclature.yaml
@@ -10,7 +10,7 @@ definitions:
     repository:
       name: common-definitions
       exclude:
-        # power generation redefined with unit GWh/h for subannual reporting
+        # power generation redefined with unit MWh/h for subannual reporting
         - name: Secondary Energy|Electricity*
         # carbon price redefined with unit EUR_2020/t CO2
         - name: Price|Carbon


### PR DESCRIPTION
Using GWh/h yields very low values, trying MWh/h for better display in the explorer

FYI @pdpsi 